### PR TITLE
feat: add `defaultHighlightMessage` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,12 @@ See [Releases page](https://github.com/azu/kindle-highlight-to-markdown/releases
 
 ## Running tests
 
-Install devDependencies and Run `npm test`:
+Add Cookie to `.cookie` file
 
-    npm test
+and Edit test/node.ts and Run tests
+
+    npm run debug
+
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "src/"
   ],
   "scripts": {
-    "main": "ts-node test/node.ts",
+    "debug": "ts-node test/node.ts",
     "build": "tsc -p . && tsc -p ./tsconfig.module.json",
     "clean": "rimraf lib/ module/",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -1,12 +1,19 @@
 import { ParseResult } from "./parse";
 import { mdImg, mdLink } from "markdown-function";
 
-export const toMarkdown = (parseResult: ParseResult): string => {
+export type ToMarkdownOptions = {
+    defaultHighlightMessage?: string;
+};
+export const toMarkdown = (parseResult: ParseResult, options?: ToMarkdownOptions): string => {
     const { title, url, coverImageUrl, annotations } = parseResult;
+    const defaultHighlightMessage = options?.defaultHighlightMessage ?? "**CAN NOT SHOW THE HIGHLIGHT**";
     const annotationsBody = annotations
         .map((annotation) => {
             const note = annotation.note ? `\n\n${annotation.note}` : "";
-            return `> ${annotation.highlight.split("\n").join("\n> ")}  
+            // Some highlight is empty string because can not get the highlight.
+            return `> ${
+                annotation.highlight === "" ? defaultHighlightMessage : annotation.highlight.split("\n").join("\n> ")
+            }  
 > Location: ${mdLink({
                 url: annotation.kindleUrl,
                 title: String(annotation.locationNumber),

--- a/test/node.ts
+++ b/test/node.ts
@@ -1,7 +1,7 @@
 import { JSDOM, CookieJar } from "jsdom";
 import * as fs from "fs/promises";
 import path from "path";
-import { parsePage } from "../src";
+import { parsePage, toMarkdown } from "../src";
 
 (async function () {
     const cookieString = (await fs.readFile(path.join(__dirname, "../.cookie"), "utf-8")).replace("^Cookie: ", "");
@@ -13,5 +13,7 @@ import { parsePage } from "../src";
     const { window } = await JSDOM.fromURL("https://read.amazon.co.jp/notebook?asin=B09RZG8KR1&contentLimitState=&", {
         cookieJar
     });
-    console.log(parsePage(window as any as Window));
+    const message = parsePage(window as any as Window);
+    console.log(message);
+    console.log(toMarkdown(message));
 })();


### PR DESCRIPTION
- Support getting empty highlight.
- `toMarkdown` render it as `"**CAN NOT SHOW THE HIGHLIGHT**"` by default
  - It can be changed by `defaultHighlightMessage` option

<img width="447" alt="image" src="https://user-images.githubusercontent.com/19714/204549217-2d4c394e-6f24-4a21-8b12-00c39ce3991b.png">


fix #3 